### PR TITLE
Fix Faulty Redirect when Deleting Author

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-
+.vscode
 *.pyc

--- a/templates/back_content/article.html
+++ b/templates/back_content/article.html
@@ -96,7 +96,7 @@
                                         <tr>
                                             <td>{{ author.full_name }}</td>
                                             <td>{{ author.email }}</td>
-                                            <td><a href="{% url 'delete_author' article.pk author.pk %}"><i
+                                            <td><a href="{% url 'bc_delete_author' article.pk author.pk %}"><i
                                                     class="fa fa-trash">
                                                 &nbsp;</i></a></td>
                                         </tr>

--- a/urls.py
+++ b/urls.py
@@ -19,4 +19,5 @@ urlpatterns = [
     url(r'^article/(?P<article_id>\d+)/galley/(?P<galley_id>\d+)/figures/(?P<file_name>.*)/$',
         article_figure,
         name='bc_article_figure'),
+    url(r'^article/(?P<article_id>\d+)/authors/(?P<author_id>\d+)/delete/$', views.delete_author, name='bc_delete_author'),
 ]

--- a/views.py
+++ b/views.py
@@ -212,3 +212,15 @@ def preview_xml_galley(request, article_id, galley_id):
     }
 
     return render(request, template, context)
+
+@editor_user_required
+def delete_author(request, article_id, author_id):
+    """Allows submitter to delete an author object."""
+    article = get_object_or_404(models.Article, pk=article_id)
+    author = get_object_or_404(core_models.Account, pk=author_id)
+    article.authors.remove(author)
+
+    if article.correspondence_author == author:
+        article.correspondence_author = None
+
+    return redirect(reverse('bc_article', kwargs={'article_id': article.pk}))


### PR DESCRIPTION
When deleting an author, currently redirects to the author page from the standard submission process. I reused the logic you used for that process and created a new view in the plugin that handles author deletion and redirects back to the back_content article page.