### PR TITLE
Set article owner and remove epub

### DIFF
--- a/templates/back_content/article.html
+++ b/templates/back_content/article.html
@@ -153,7 +153,6 @@
                             <th>Replace</th>
                             <th>History</th>
                             <th>Create PDF</th>
-                            <th>Create EPUB</th>
                         </tr>
                         {% for galley in galleys %}
                             {% can_view_file galley.file as can_view_file_flag %}
@@ -188,21 +187,6 @@
                                     {% if galley.file.mime_type == 'application/xml' and not galley.has_missing_image_files %}
                                         <a href="{% url 'cassius_generate' galley.pk %}?return={{ request.path|urlencode }}">
                                             <i class="fa fa-file-text-o">&nbsp;</i>
-                                        </a>
-                                    {% elif not galley.file.mime_type == 'application/xml' %}
-                                        Function for XML only.
-                                    {% elif galley.file.mime_type == 'application/xml' and galley.has_missing_image_files %}
-                                        <p><span data-tooltip aria-haspopup="true" class="has-tip top"
-                                                 data-disable-hover="false"
-                                                 tabindex="2"
-                                                 title="{% has_missing_supplements galley %}">Missing Supplements</span>
-                                        </p>
-                                    {% endif %}
-                                </td>
-                                <td>
-                                    {% if galley.file.mime_type == 'application/xml' and not galley.has_missing_image_files %}
-                                        <a href="{% url 'epub_generate' galley.pk %}?return={{ request.path|urlencode }}">
-                                            <i class="fa fa-book">&nbsp;</i>
                                         </a>
                                     {% elif not galley.file.mime_type == 'application/xml' %}
                                         Function for XML only.

--- a/views.py
+++ b/views.py
@@ -24,6 +24,7 @@ def index(request):
         article = models.Article.objects.create(
             journal=request.journal,
             date_accepted=timezone.now(),
+            owner=request.user,
             is_import=True,
             article_agreement='This record was created using the back '
                               'content plugin.',


### PR DESCRIPTION
- Set the article owner to the currently logged in user.  (our pub system requires it but also just seems like an oversight)
- Remove "Create epub" column from galleys table, it was misaligned but according to Justin Andy said it should be removed anyway

(Just a note, I noticed that the back_content plugin doesn't work with main though we are also stuck on 1.7.X until we migrate to postgres)